### PR TITLE
Attempt to add support for interpreting word input as regex

### DIFF
--- a/internal/count/count.go
+++ b/internal/count/count.go
@@ -186,13 +186,29 @@ func SingleWordCount(target string, word string) (string, error) {
 
 	userData := data[target]
 
-	word = sanitizeWord(word)
+	wordCount := 0
+	if strings.HasPrefix(word, "regexp=") {
+		reStr := strings.split(word, "regexp=")[1]
+		re, err := regex.Compile(reStr)
+		if err != nil {
+			return fmt.Sprintf("%s is not a valid regexp", reStr), nil
+		}
+		for w := range userData {
+			if re.Match(w) {
+				wordCount++
+			}
+		}
+	} else {
+		word = sanitizeWord(word)
 
-	if len(word) == 0 {
-		return "", errors.New("word contains only sanitized chars")
+		if len(word) == 0 {
+			return "", errors.New("word contains only sanitized chars")
+		}
+
+		wordCount = userData.counts[word]
 	}
 
-	if _, ok := userData.counts[word]; !ok {
+	if _, ok := wordCount; !ok {
 		return fmt.Sprintf("user %q has never said that", target), nil
 	}
 

--- a/internal/count/count.go
+++ b/internal/count/count.go
@@ -191,10 +191,14 @@ func SingleWordCount(target string, word string) (string, error) {
 		reStr := strings.split(word, "regexp=")[1]
 		re, err := regex.Compile(reStr)
 		if err != nil {
-			return fmt.Sprintf("%s is not a valid regexp", reStr), nil
+			return fmt.Sprintf("%s is not a valid pattern", reStr), err
 		}
 		for w := range userData {
-			if re.Match(w) {
+			matched, err := re.Match([]byte(w))
+			if (err != nil {
+				return fmt.Sprintf("Matching failed for regex %s", reStr), err
+			})
+			if matched {
 				wordCount++
 			}
 		}

--- a/internal/count/count.go
+++ b/internal/count/count.go
@@ -195,9 +195,9 @@ func SingleWordCount(target string, word string) (string, error) {
 		}
 		for w := range userData {
 			matched, err := re.Match([]byte(w))
-			if (err != nil {
+			if err != nil {
 				return fmt.Sprintf("Matching failed for regex %s", reStr), err
-			})
+			}
 			if matched {
 				wordCount++
 			}


### PR DESCRIPTION
Første Go-koden jeg har skrevet i mitt liv + 100% utestet, så dette må jo bare bli bra.

Input-ordet sjekkes for prefix "regexp=", hvis den har det så tolkes resten av strengen som regexen som skal matches over userData.  Prøvde å få det inn med så få endringer i resten av koden som mulig, derfor er det litt schtøggt implementert.

Mulige fallgruver:
* Input saniteres **ikke** hvis den har "regexp=" som prefix, siden det hadde lowercaset ting, som er dumt. idk om det kan være et problem ellers.
* Jeg aner ikke hva jeg holder på med.